### PR TITLE
Use status 'alum' only for alumni@bostonhacks.io

### DIFF
--- a/github.rb
+++ b/github.rb
@@ -6,6 +6,7 @@ puts '~~~ Starting github team update ~~~'
 # load the team.yml file and get the members from it
 config = YAML.load_file('team.yml')
 members = config['members']
+members.select! { |member| member['status'] == 'active' }
 
 # get the new permissions for the members from the file
 new_permissions = {}

--- a/team.yml
+++ b/team.yml
@@ -310,7 +310,7 @@ members:
     sendgrid:
       email: lkwatson@bu.edu
       routes:
-        - alum@bostonhacks.io
+        - alumni@bostonhacks.io
   - name: Mariana Garces Dematte
     github:
       username: maridematte
@@ -519,8 +519,8 @@ routes:
   - name: contact@bostonhacks.io
     formatted: BostonHacks [Contact] <contact@bostonhacks.io>
     description: General catch-all bostonhacks emails
-  - name: alum@bostonhacks.io
-    formatted: BostonHacks [Alumni] <alum@bostonhacks.io>
+  - name: alumni@bostonhacks.io
+    formatted: BostonHacks [Alumni] <alumni@bostonhacks.io>
     description: Active alumni mailing list
   - name: mail@bostonhacks.io
     formatted: BostonHacks [Mailchimp] <mail@bostonhacks.io>

--- a/team_drive.rb
+++ b/team_drive.rb
@@ -5,11 +5,13 @@ require 'googleauth/stores/file_token_store'
 require './drive_token_store.rb'
 
 # team_emails = set of emails to be granted access
-team_info = YAML.load_file("team.yml")
-team_emails = Set.new
+config = YAML.load_file('team.yml')
+members = config['members']
+members.select! { |member| member['status'] == 'active' }
 
-team_info["members"].each do |entry|
-  email = entry["sendgrid"]["email"]
+team_emails = Set.new
+members.each do |member|
+  email = member["sendgrid"]["email"]
   team_emails.add(email)
 end
 


### PR DESCRIPTION
Only adds members with status 'active' to GitHub and Google Drive. Status 'alum' will still receive emails from alumni@bostonhacks.io