### PR TITLE
Adding self to alumni email

### DIFF
--- a/team.yml
+++ b/team.yml
@@ -354,12 +354,11 @@ members:
   - name: Michael Hendrick
     github:
       username: mhendrick98
-      role: admin
+      role: member
     mailgun:
       email: mhendric@bu.edu
       routes:
-        - contact@bostonhacks.io
-        - tech@bostonhacks.io
+        - alumni@bostonhacks.io
     status: active
   - name: Nam Pham
     github:


### PR DESCRIPTION
# Description

Added myself to the alumni email

# Tests
I affirm that:
- [X] The `username` field is my GitHub username
- [X] I've double checked my email is correct
- [X] I have 2-factor authentication turned on on my github account
