### PR TITLE
Change self to alumni

### DIFF
--- a/team.yml
+++ b/team.yml
@@ -537,7 +537,7 @@ members:
     mailgun:
       email: wpartrid@bu.edu
       routes:
-        - contact@bostonhacks.io
+        - alumni@bostonhacks.io
     status: inactive
   - name: Xavier Ruiz
     github:


### PR DESCRIPTION
# Description

Setting myself as an alum to deftly dodge the definitely-destined deluge of day-of emails.

Could someone pls add me back to the org


# Tests
I affirm that:
- [x] The `username` field is my GitHub username
- [x] I've double checked my email is correct
- [x] I have 2-factor authentication turned on on my github account
