### PR TITLE
Added Kian Boon

### DIFF
--- a/team.yml
+++ b/team.yml
@@ -728,6 +728,15 @@ members:
         - contact@bostonhacks.io
         - sponsor@bostonhacks.io
     status: active
+  - name: Kian Boon Tan
+    github:
+      username: kbbtan
+      role: member
+    mailgun:
+      email: kbbtan@bu.edu
+      routes:
+        - contact@bostonhacks.io
+    status: active
 mailgun:
   routes:
     - name: contact@bostonhacks.io


### PR DESCRIPTION
# Description

Added Kian Boon Tan as member to contact@bostonhacks.io mailing list.

# Tests
I affirm that:
- [x] The `username` field is my GitHub username
- [x] I've double checked my email is correct
- [x] I have 2-factor authentication turned on on my github account
